### PR TITLE
v5 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "chromedriver": "^2.37.0",
     "css": "2.2.4",
     "css-url-parser": "^1.1.3",
-    "geckodriver": "^1.11.0",
+    "geckodriver": "^1.16.0",
     "is-absolute-url": "^2.1.0",
     "request-promise-native": "^1.0.5",
     "webdriverio": "4.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@applitools/eyes.webdriverio",
-  "version": "2.0.0",
+  "name": "@wdio/eyes.webdriverio",
+  "version": "2.0.5",
   "description": "Applitools Eyes SDK for Webdriverio ",
   "main": "index.js",
   "scripts": {

--- a/src/Eyes.js
+++ b/src/Eyes.js
@@ -1355,7 +1355,7 @@ class Eyes extends EyesBase {
       return undefined;
     }
 
-    return this.getPromiseFactory().resolve(this.getRemoteWebDriver().requestHandler.sessionID);
+    return this.getPromiseFactory().resolve(this.getRemoteWebDriver().sessionId);
   };
 
 

--- a/src/EyesWDIOUtils.js
+++ b/src/EyesWDIOUtils.js
@@ -374,7 +374,7 @@ class EyesWDIOUtils {
 
     return executor.executeScript(script).catch(e => {
       throw new EyesDriverOperationError('Failed to set overflow', e);
-    }
+    })
   }
 
 

--- a/src/EyesWDIOUtils.js
+++ b/src/EyesWDIOUtils.js
@@ -345,9 +345,9 @@ class EyesWDIOUtils {
     // scrollHeight might be smaller (!) than the clientHeight, which is why we take the maximum between them.
     return executor.executeScript(EyesWDIOUtils.JS_GET_CONTENT_ENTIRE_SIZE).then(value => {
       return new RectangleSize(parseInt(value[0], 10) || 0, parseInt(value[1], 10) || 0);
-    } catch (e) {
+    }, (e) => {
       throw new EyesDriverOperationError("Failed to extract entire size!", e);
-    }
+    });
   }
 
 
@@ -386,7 +386,7 @@ class EyesWDIOUtils {
   static isBodyOverflowHidden(executor) {
     return executor.executeScript(EyesWDIOUtils.JS_GET_IS_BODY_OVERFLOW_HIDDEN).catch(e => {
       throw new EyesDriverOperationError('Failed to get state of body overflow', e);
-    }
+    });
   }
 
 
@@ -414,7 +414,7 @@ class EyesWDIOUtils {
 
     return executor.executeScript(script).catch(e => {
       throw new EyesDriverOperationError('Failed to set body overflow', e);
-    }
+    });
   }
 
 

--- a/src/capture/TakesScreenshotImageProvider.js
+++ b/src/capture/TakesScreenshotImageProvider.js
@@ -26,7 +26,7 @@ class TakesScreenshotImageProvider extends ImageProvider {
     this._logger.verbose("Getting screenshot as base64...");
 
     const that = this;
-    return this._tsInstance.remoteWebDriver.saveScreenshot().then(screenshot64 => {
+    return this._tsInstance.remoteWebDriver.takeScreenshot().then(screenshot64 => {
       that._logger.verbose("Done getting base64! Creating MutableImage...");
       return new MutableImage(screenshot64, that._tsInstance.getPromiseFactory());
     });


### PR DESCRIPTION
## Problem

WebdriverIO is about to release a new major version that comes with a variety of breaking changes. This package wouldn't be compatible with it anymore.

## Solution

Modify `EyesWDIOUtils.js` to use new commands and change the way how results are handled.

## Comment

This is work in progress. There might be changes before release that might affect this PR. So please stay tuned.

Ref: https://github.com/webdriverio/v5/pull/79