### PR TITLE
Restrict eyes.sdk.core version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "See LICENSE file",
   "repository": "https://github.com/applitools/eyes.webdriverio.javascript",
   "dependencies": {
-    "@applitools/eyes.sdk.core": "^1.7.0",
+    "@applitools/eyes.sdk.core": "1.8.x",
     "chromedriver": "^2.37.0",
     "geckodriver": "^1.11.0",
     "webdriverio": "4.12.0"


### PR DESCRIPTION
With the latest version of eyes.sdk.core (1.9), the following error is thrown when running `check`:
```
TypeError: Cannot read property 'setPosition' of undefined
    at Eyes.check (node_modules/@applitools/eyes.webdriverio/src/Eyes.js:267:35)
    at Object.<anonymous> (wdio.conf.js:220:31)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
```
This PR restricts the version to 1.8.x, which is the latest known working version of the sdk.core dependency. I've tested it with this version locally and it resolves the issue. 