### PR TITLE
remove chromedriver and geckodriver deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,8 @@
   "dependencies": {
     "@applitools/dom-utils": "~4.5.0",
     "@applitools/eyes.sdk.core": "~2.3.0",
-    "chromedriver": "^2.37.0",
     "css": "2.2.4",
     "css-url-parser": "^1.1.3",
-    "geckodriver": "^1.11.0",
     "is-absolute-url": "^2.1.0",
     "request-promise-native": "^1.0.5",
     "webdriverio": "4.12.0"


### PR DESCRIPTION
Removed chromedriver and geckodriver from dependencies, both of them are still in dev dependencies. 